### PR TITLE
Fix typo in template import

### DIFF
--- a/inst/template/R/test_extract.R
+++ b/inst/template/R/test_extract.R
@@ -1,6 +1,6 @@
 context("extract")
 
-testthat::test_file("extracted data is as expected", {
+testthat::test_that("extracted data is as expected", {
   ## Example impl, extend or modify as required.
   expect_false(is.null(extracted_data))
 })

--- a/inst/template/R/test_transform.R
+++ b/inst/template/R/test_transform.R
@@ -1,6 +1,6 @@
 context("transform")
 
-testthat::test_file("transformed data is as expected", {
+testthat::test_that("transformed data is as expected", {
   ## Example impl, extend or modify as required.
   expect_false(is.null(transformed_data))
 })


### PR DESCRIPTION
Small typo in template import found whilst creating example.