### PR TITLE
i2752 - Make connection available to tests

### DIFF
--- a/R/extract_runner.R
+++ b/R/extract_runner.R
@@ -20,7 +20,7 @@ run_extract <- function(con, extract, path, extract_test){
     stop("DB connection is not valid cannot extract data")
   }
   if (!is.null(extract_test)) {
-    test_results <- run_extract_tests(path, extract_test, extracted_data)
+    test_results <- run_extract_tests(path, extract_test, extracted_data, con)
     if (!all_passed(test_results)) {
       stop("Not all extract tests passed. Fix tests before proceeding.")
     }

--- a/R/load_runner.R
+++ b/R/load_runner.R
@@ -26,7 +26,7 @@ run_load <- function(load, con, transformed_data, test_queries, path,
   on.exit(if (transaction_active) {DBI::dbRollback(con)})
   load(transformed_data, con)
   after <- test_queries(con)
-  test_results <- run_load_tests(path, test_file, before, after)
+  test_results <- run_load_tests(path, test_file, before, after, con)
   if (all_passed(test_results)) {
     DBI::dbCommit(con)
     transaction_active <- FALSE

--- a/R/test_runner.R
+++ b/R/test_runner.R
@@ -1,24 +1,27 @@
-run_load_tests <- function(path, test_file, before, after,
+run_load_tests <- function(path, test_file, before, after, con,
                            reporter = testthat::default_reporter()) {
   env <- new.env(parent = .GlobalEnv)
   env$before <- before
   env$after <- after
+  env$con <- con
   test_results <- testthat::test_file(file.path(path, test_file), env = env,
                                       reporter = reporter)
 }
 
-run_extract_tests <- function(path, test_file, extracted_data,
+run_extract_tests <- function(path, test_file, extracted_data, con,
                               reporter = testthat::default_reporter()) {
   env <- new.env(parent = .GlobalEnv)
   env$extracted_data <- extracted_data
+  env$con <- con
   test_results <- testthat::test_file(file.path(path, test_file), env = env,
                                       reporter = reporter)
 }
 
-run_transform_tests <- function(path, test_file, transformed_data,
+run_transform_tests <- function(path, test_file, transformed_data, con,
                                 reporter = testthat::default_reporter()) {
   env <- new.env(parent = .GlobalEnv)
   env$transformed_data <- transformed_data
+  env$con <- con
   test_results <- testthat::test_file(file.path(path, test_file), env = env,
                                       reporter = reporter)
 }

--- a/R/transform_runner.R
+++ b/R/transform_runner.R
@@ -27,7 +27,7 @@ run_transform <-
     verify_data(con, transformed_data)
     if (!is.null(transform_test)) {
       test_results <-
-        run_transform_tests(path, transform_test, transformed_data)
+        run_transform_tests(path, transform_test, transformed_data, con)
       if (!all_passed(test_results)) {
         stop("Not all transform tests passed. Fix tests before proceeding.")
       }

--- a/tests/testthat/example_tests/connection_extract_test.R
+++ b/tests/testthat/example_tests/connection_extract_test.R
@@ -1,0 +1,5 @@
+context("connection-extract-test")
+
+testthat::test_that("valid connection is available", {
+  expect_true(DBI::dbIsValid(con))
+})

--- a/tests/testthat/example_tests/connection_load_test.R
+++ b/tests/testthat/example_tests/connection_load_test.R
@@ -1,0 +1,5 @@
+context("connection-load-test")
+
+testthat::test_that("valid connection is available", {
+  expect_true(DBI::dbIsValid(con))
+})

--- a/tests/testthat/example_tests/connection_transform_test.R
+++ b/tests/testthat/example_tests/connection_transform_test.R
@@ -1,0 +1,5 @@
+context("connection-transform-test")
+
+testthat::test_that("valid connection is available", {
+  expect_true(DBI::dbIsValid(con))
+})

--- a/tests/testthat/example_tests/passing_load_test.R
+++ b/tests/testthat/example_tests/passing_load_test.R
@@ -1,4 +1,4 @@
-context("failing-test")
+context("passing-load-test")
 
 testthat::test_that("No of rows in people increases by 2", {
   expect_equal(after$count, before$count + 2)

--- a/tests/testthat/helper-dettl.R
+++ b/tests/testthat/helper-dettl.R
@@ -42,3 +42,7 @@ trigger_dbi_warning <- function() {
 }
 
 trigger_dbi_warning()
+
+get_local_connection <- function() {
+  DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+}

--- a/tests/testthat/test-test-runner.R
+++ b/tests/testthat/test-test-runner.R
@@ -22,14 +22,14 @@ testthat::test_that("user specified extract tests can be run", {
   test_path <- "example_tests/"
   test_file <- "failing_extract_test.R"
   extracted_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
-  result <- run_extract_tests(test_path, test_file, extracted_data,
+  result <- run_extract_tests(test_path, test_file, extracted_data, NULL,
                               SilentReporter)
 
   expect_false(all_passed(result))
 
   test_path <- "example_tests/"
   test_file <- "passing_extract_test.R"
-  result <- run_extract_tests(test_path, test_file, extracted_data,
+  result <- run_extract_tests(test_path, test_file, extracted_data, NULL,
                               SilentReporter)
 
   expect_true(all_passed(result))
@@ -39,15 +39,41 @@ testthat::test_that("user specified transform tests can be run", {
   test_path <- "example_tests/"
   test_file <- "failing_transform_test.R"
   transformed_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
-  result <- run_transform_tests(test_path, test_file, transformed_data,
+  result <- run_transform_tests(test_path, test_file, transformed_data, NULL,
                                 SilentReporter)
 
   expect_false(all_passed(result))
 
   test_path <- "example_tests/"
   test_file <- "passing_transform_test.R"
-  result <- run_transform_tests(test_path, test_file, transformed_data,
+  result <- run_transform_tests(test_path, test_file, transformed_data, NULL,
                                 SilentReporter)
 
   expect_true(all_passed(result))
+})
+
+testthat::test_that("connection is available to tests", {
+  test_path <- "example_tests/"
+  con <- get_local_connection()
+  on.exit(DBI::dbDisconnect(con))
+  test_file <- "connection_extract_test.R"
+  extracted_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
+  result <- run_extract_tests(test_path, test_file, extracted_data, con,
+                              SilentReporter)
+  expect_true(all_passed(result))
+
+  test_file <- "connection_transform_test.R"
+  transformed_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
+  result <- run_transform_tests(test_path, test_file, transformed_data, con,
+                                SilentReporter)
+  expect_true(all_passed(result))
+
+  test_path <- "example_tests/"
+  test_file <- "connection_load_test.R"
+  before <- list(count = 0)
+  after <- list(count = 2)
+  result <- run_load_tests(test_path, test_file, before, after, con,
+                           SilentReporter)
+  expect_true(all_passed(result))
+
 })


### PR DESCRIPTION
This makes connection available to the extract, transform and load tests

Generally expect we will want to inspect the database to make sure that the load stage has passed successfully. 

More specifically in porting example data we have instances where we want to access the db during the transform stage to read fks for use in data validation.