### PR TITLE
Add dry run option to run_import

### DIFF
--- a/R/dettl.R
+++ b/R/dettl.R
@@ -48,9 +48,9 @@ dataImport <- R6::R6Class(
                                            private$transform_test_)
     },
 
-    load = function() {
+    load = function(dry_run) {
       run_load(private$load_, private$con, private$transformed_data,
-               private$test_queries, private$path, private$load_test_)
+               private$test_queries, private$path, private$load_test_, dry_run)
       invisible(TRUE)
     },
 

--- a/R/dettl_runner.R
+++ b/R/dettl_runner.R
@@ -32,11 +32,14 @@ new_import <- function(path, db_name = NULL) {
 #' @param import The dataImport object.
 #' @param run_stages Which stages should be run in the import process. Runs all
 #' if NULL.
+#' @param dry_run If TRUE then any database changes are rolled back when the
+#' import completes. i.e. the load stage can be run and tests executed but the
+#' db will be rolled back.
 #'
 #' @return The processed dataImport object.
 #' @export
 #'
-run_import <- function(import, run_stages = NULL) {
+run_import <- function(import, run_stages = NULL, dry_run = FALSE) {
   if (is.null(import) || class(import) != "dataImport") {
     stop(
       "Can only run import for non null data import with class 'dataImport'.")
@@ -48,7 +51,7 @@ run_import <- function(import, run_stages = NULL) {
     import$transform()
   }
   if (is.null(run_stages) || "load" %in% run_stages) {
-    import$load()
+    import$load(dry_run)
   }
   import
 }

--- a/man/run_import.Rd
+++ b/man/run_import.Rd
@@ -4,13 +4,17 @@
 \alias{run_import}
 \title{Run the import process for a data_import object.}
 \usage{
-run_import(import, run_stages = NULL)
+run_import(import, run_stages = NULL, dry_run = FALSE)
 }
 \arguments{
 \item{import}{The dataImport object.}
 
 \item{run_stages}{Which stages should be run in the import process. Runs all
 if NULL.}
+
+\item{dry_run}{If TRUE then any database changes are rolled back when the
+import completes. i.e. the load stage can be run and tests executed but the
+db will be rolled back.}
 }
 \value{
 The processed dataImport object.

--- a/man/run_load.Rd
+++ b/man/run_load.Rd
@@ -4,7 +4,8 @@
 \alias{run_load}
 \title{Run the load step ensuring tests pass before db changes are committed.}
 \usage{
-run_load(load, con, transformed_data, test_queries, path, test_file)
+run_load(load, con, transformed_data, test_queries, path, test_file,
+  dry_run)
 }
 \arguments{
 \item{load}{The load function for making the DB changes.}
@@ -21,6 +22,10 @@ and after the load is run. Used within the tests to check changes to the DB.}
 
 \item{test_file}{Path to file containing the testthat tests for verifying the
 DB changes.}
+
+\item{dry_run}{If TRUE then any database changes are rolled back when the
+import completes. i.e. the load stage can be run and tests executed but the
+db will be rolled back.}
 }
 \description{
 Runs the load function on the DB within a transaction. Then run a set of


### PR DESCRIPTION
* Allows the import to be run end to end using `run_import` with a `dry_run` option which will rollback any changes made to the db at the end after all tests have been run
* Expect will be used by developer of imports to run all tests and code written so far when the import is not complete