### PR TITLE
Normalise path when import object is created

### DIFF
--- a/R/dettl_runner.R
+++ b/R/dettl_runner.R
@@ -10,6 +10,7 @@
 #'
 new_import <- function(path, db_name = NULL) {
 
+  path <- normalizePath(path, mustWork = TRUE)
   dettl_config <- read_config(path)
 
   import <- dataImport$new(path,

--- a/tests/testthat/test-test-runner.R
+++ b/tests/testthat/test-test-runner.R
@@ -5,14 +5,14 @@ testthat::test_that("user specified load tests can be run", {
   test_file <- "failing_load_test.R"
   before <- list(count = 0)
   after <- list(count = 2)
-  result <- run_load_tests(test_path, test_file, before, after,
+  result <- run_load_tests(test_path, test_file, before, after, NULL,
                            SilentReporter)
 
   expect_false(all_passed(result))
 
   test_path <- "example_tests/"
   test_file <- "passing_load_test.R"
-  result <- run_load_tests(test_path, test_file, before, after,
+  result <- run_load_tests(test_path, test_file, before, after, NULL,
                            SilentReporter)
 
   expect_true(all_passed(result))


### PR DESCRIPTION
PR
* Use a normalised path when calling `new_import`
* Also fixes a discovered issue with tests printing output from failing load tests which should run silently (had regressed due to a method signature change)