### PR TITLE
Improve messages around testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ sudo: false
 cache: packages
 r_packages:
   - covr
-before_script:
-  - Rscript -e 'vaultr::vault_test_server_install()'
 # Workaround for devtools bug see https://github.com/r-lib/devtools/issues/2020
 # Should be removed once that is fixed
+before_install:
   - R -e 'source("https://install-github.me/r-lib/remotes")'
+before_script:
+  - Rscript -e 'vaultr::vault_test_server_install()'
   - R CMD INSTALL .
 after_success:
   - Rscript -e 'devtools::test()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ r_packages:
   - covr
 before_script:
   - Rscript -e 'vaultr::vault_test_server_install()'
+# Workaround for devtools bug see https://github.com/r-lib/devtools/issues/2020
+# Should be removed once that is fixed
+  - R -e 'source("https://install-github.me/r-lib/remotes")'
   - R CMD INSTALL .
 after_success:
   - Rscript -e 'devtools::test()'

--- a/R/dettl.R
+++ b/R/dettl.R
@@ -49,7 +49,7 @@ dataImport <- R6::R6Class(
     },
 
     load = function(dry_run) {
-      run_load(private$load_, private$con, private$transformed_data,
+      run_load(private$con, private$load_, private$transformed_data,
                private$test_queries, private$path, private$load_test_, dry_run)
       invisible(TRUE)
     },

--- a/R/extract_runner.R
+++ b/R/extract_runner.R
@@ -20,9 +20,13 @@ run_extract <- function(con, extract, path, extract_test){
     stop("DB connection is not valid cannot extract data")
   }
   if (!is.null(extract_test)) {
-    test_results <- run_extract_tests(path, extract_test, extracted_data, con)
+    test_path <- file.path(path, extract_test)
+    message(sprintf("Running extract tests %s", test_path))
+    test_results <- run_extract_tests(test_path, extracted_data, con)
     if (!all_passed(test_results)) {
       stop("Not all extract tests passed. Fix tests before proceeding.")
+    } else {
+      message("All extract tests passed.")
     }
   }
   extracted_data

--- a/R/test_runner.R
+++ b/R/test_runner.R
@@ -1,29 +1,26 @@
-run_load_tests <- function(path, test_file, before, after, con,
+run_load_tests <- function(path, before, after, con,
                            reporter = testthat::default_reporter()) {
   env <- new.env(parent = .GlobalEnv)
   env$before <- before
   env$after <- after
   env$con <- con
-  test_results <- testthat::test_file(file.path(path, test_file), env = env,
-                                      reporter = reporter)
+  test_results <- testthat::test_file(path, env = env, reporter = reporter)
 }
 
-run_extract_tests <- function(path, test_file, extracted_data, con,
+run_extract_tests <- function(path, extracted_data, con,
                               reporter = testthat::default_reporter()) {
   env <- new.env(parent = .GlobalEnv)
   env$extracted_data <- extracted_data
   env$con <- con
-  test_results <- testthat::test_file(file.path(path, test_file), env = env,
-                                      reporter = reporter)
+  test_results <- testthat::test_file(path, env = env, reporter = reporter)
 }
 
-run_transform_tests <- function(path, test_file, transformed_data, con,
+run_transform_tests <- function(path, transformed_data, con,
                                 reporter = testthat::default_reporter()) {
   env <- new.env(parent = .GlobalEnv)
   env$transformed_data <- transformed_data
   env$con <- con
-  test_results <- testthat::test_file(file.path(path, test_file), env = env,
-                                      reporter = reporter)
+  test_results <- testthat::test_file(path, env = env, reporter = reporter)
 }
 
 ## return if all tests are successful w/o error

--- a/R/transform_runner.R
+++ b/R/transform_runner.R
@@ -14,22 +14,22 @@
 #' @return The successfully transformed data.
 #' @keywords internal
 #'
-run_transform <-
-  function(con,
-           transform,
-           path,
-           extracted_data,
-           transform_test) {
+run_transform <- function(con, transform, path, extracted_data,
+                          transform_test) {
     if (is.null(extracted_data)) {
       stop("Cannot run transform as no data has been extracted.")
     }
     transformed_data <- transform(extracted_data)
     verify_data(con, transformed_data)
     if (!is.null(transform_test)) {
+      test_path <- file.path(path, transform_test)
+      message(sprintf("Running transform tests %s", test_path))
       test_results <-
-        run_transform_tests(path, transform_test, transformed_data, con)
+        run_transform_tests(test_path, transformed_data, con)
       if (!all_passed(test_results)) {
         stop("Not all transform tests passed. Fix tests before proceeding.")
+      } else {
+        message("All transform tests passed.")
       }
     }
     transformed_data

--- a/man/run_load.Rd
+++ b/man/run_load.Rd
@@ -4,13 +4,13 @@
 \alias{run_load}
 \title{Run the load step ensuring tests pass before db changes are committed.}
 \usage{
-run_load(load, con, transformed_data, test_queries, path, test_file,
+run_load(con, load, transformed_data, test_queries, path, test_file,
   dry_run)
 }
 \arguments{
-\item{load}{The load function for making the DB changes.}
-
 \item{con}{Connection to the database.}
+
+\item{load}{The load function for making the DB changes.}
 
 \item{transformed_data}{List of data frames representing the data to be
 loaded to the DB.}

--- a/tests/testthat/test-extract-runner.R
+++ b/tests/testthat/test-extract-runner.R
@@ -1,0 +1,20 @@
+context("load_runner")
+
+testthat::test_that("messages are printed to console when tests are run", {
+  extract_func <- function(data, con) {}
+  db_name <- "test.sqlite"
+  prepare_example_db(db_name)
+  on.exit(unlink(db_name), add = TRUE)
+  con <- db_connect("test", ".")
+  path <- "example_tests"
+  test_file <- "connection_extract_test.R"
+  default_reporter <- testthat::default_reporter()
+  options(testthat.default_reporter = "Silent")
+  on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
+
+  expect_message(run_extract(con, extract_func, path, test_file),
+                 "Running extract tests example_tests/connection_extract_test.R")
+
+  expect_message(run_extract(con, extract_func, path, test_file),
+                 "All extract tests passed.")
+})

--- a/tests/testthat/test-load-runner.R
+++ b/tests/testthat/test-load-runner.R
@@ -1,0 +1,24 @@
+context("load_runner")
+
+testthat::test_that("messages are printed to console when tests are run", {
+  load_func <- function(data, con) {}
+  db_name <- "test.sqlite"
+  prepare_example_db(db_name)
+  on.exit(unlink(db_name), add = TRUE)
+  con <- db_connect("test", ".")
+  transformed_data <- list()
+  test_queries <- function(con) {}
+  path <- "example_tests"
+  test_file <- "connection_load_test.R"
+  default_reporter <- testthat::default_reporter()
+  options(testthat.default_reporter = "Silent")
+  on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
+
+  expect_message(run_load(con, load_func, transformed_data, test_queries,
+                          path = path, test_file = test_file, dry_run = FALSE),
+                 "Running load tests example_tests/connection_load_test.R")
+
+  expect_message(run_load(con, load_func, transformed_data, test_queries,
+                          path = path, test_file = test_file, dry_run = FALSE),
+                 "All tests passed, commiting changes to database.")
+})

--- a/tests/testthat/test-test-runner.R
+++ b/tests/testthat/test-test-runner.R
@@ -1,79 +1,65 @@
 context("test-runner")
 
 testthat::test_that("user specified load tests can be run", {
-  test_path <- "example_tests/"
-  test_file <- "failing_load_test.R"
+  test_path <- "example_tests/failing_load_test.R"
   before <- list(count = 0)
   after <- list(count = 2)
-  result <- run_load_tests(test_path, test_file, before, after, NULL,
-                           SilentReporter)
+  result <- run_load_tests(test_path, before, after, NULL, SilentReporter)
 
   expect_false(all_passed(result))
 
-  test_path <- "example_tests/"
-  test_file <- "passing_load_test.R"
-  result <- run_load_tests(test_path, test_file, before, after, NULL,
-                           SilentReporter)
+  test_path <- "example_tests/passing_load_test.R"
+  result <- run_load_tests(test_path, before, after, NULL, SilentReporter)
 
   expect_true(all_passed(result))
 })
 
 testthat::test_that("user specified extract tests can be run", {
-  test_path <- "example_tests/"
-  test_file <- "failing_extract_test.R"
+  test_path <- "example_tests/failing_extract_test.R"
   extracted_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
-  result <- run_extract_tests(test_path, test_file, extracted_data, NULL,
-                              SilentReporter)
+  result <- run_extract_tests(test_path, extracted_data, NULL, SilentReporter)
 
   expect_false(all_passed(result))
 
-  test_path <- "example_tests/"
-  test_file <- "passing_extract_test.R"
-  result <- run_extract_tests(test_path, test_file, extracted_data, NULL,
-                              SilentReporter)
+  test_path <- "example_tests/passing_extract_test.R"
+  result <- run_extract_tests(test_path, extracted_data, NULL, SilentReporter)
 
   expect_true(all_passed(result))
 })
 
 testthat::test_that("user specified transform tests can be run", {
-  test_path <- "example_tests/"
-  test_file <- "failing_transform_test.R"
+  test_path <- "example_tests/failing_transform_test.R"
   transformed_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
-  result <- run_transform_tests(test_path, test_file, transformed_data, NULL,
+  result <- run_transform_tests(test_path, transformed_data, NULL,
                                 SilentReporter)
 
   expect_false(all_passed(result))
 
-  test_path <- "example_tests/"
-  test_file <- "passing_transform_test.R"
-  result <- run_transform_tests(test_path, test_file, transformed_data, NULL,
+  test_path <- "example_tests/passing_transform_test.R"
+  result <- run_transform_tests(test_path, transformed_data, NULL,
                                 SilentReporter)
 
   expect_true(all_passed(result))
 })
 
 testthat::test_that("connection is available to tests", {
-  test_path <- "example_tests/"
+  test_path <- "example_tests/connection_extract_test.R"
   con <- get_local_connection()
   on.exit(DBI::dbDisconnect(con))
-  test_file <- "connection_extract_test.R"
   extracted_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
-  result <- run_extract_tests(test_path, test_file, extracted_data, con,
-                              SilentReporter)
+  result <- run_extract_tests(test_path, extracted_data, con, SilentReporter)
   expect_true(all_passed(result))
 
-  test_file <- "connection_transform_test.R"
+  test_path <- "example_tests/connection_transform_test.R"
   transformed_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
-  result <- run_transform_tests(test_path, test_file, transformed_data, con,
+  result <- run_transform_tests(test_path, transformed_data, con,
                                 SilentReporter)
   expect_true(all_passed(result))
 
-  test_path <- "example_tests/"
-  test_file <- "connection_load_test.R"
+  test_path <- "example_tests/connection_load_test.R"
   before <- list(count = 0)
   after <- list(count = 2)
-  result <- run_load_tests(test_path, test_file, before, after, con,
-                           SilentReporter)
+  result <- run_load_tests(test_path, before, after, con, SilentReporter)
   expect_true(all_passed(result))
 
 })

--- a/tests/testthat/test-transform-runner.R
+++ b/tests/testthat/test-transform-runner.R
@@ -61,3 +61,30 @@ testthat::test_that("verification passes if data adheres to schema", {
   colnames(transformed_data$people) <- c("name", "age", "height")
   expect_silent(verify_data(con, transformed_data))
 })
+
+context("load_runner")
+
+testthat::test_that("messages are printed to console when tests are run", {
+  transform_func <- function(data, con) {
+    list(people = stats::setNames(
+      c("Test", 2, 3),
+      c("name", "age", "height")
+    ))
+  }
+  db_name <- "test.sqlite"
+  prepare_example_db(db_name)
+  on.exit(unlink(db_name), add = TRUE)
+  con <- db_connect("test", ".")
+  path <- "example_tests"
+  test_file <- "connection_transform_test.R"
+  default_reporter <- testthat::default_reporter()
+  options(testthat.default_reporter = "Silent")
+  on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
+  data <- list()
+
+  expect_message(run_transform(con, transform_func, path, data, test_file),
+                 "Running transform tests example_tests/connection_transform_test.R")
+
+  expect_message(run_transform(con, transform_func, path, data, test_file),
+                 "All transform tests passed.")
+})

--- a/tests/testthat/test-transform-runner.R
+++ b/tests/testthat/test-transform-runner.R
@@ -62,8 +62,6 @@ testthat::test_that("verification passes if data adheres to schema", {
   expect_silent(verify_data(con, transformed_data))
 })
 
-context("load_runner")
-
 testthat::test_that("messages are printed to console when tests are run", {
   transform_func <- function(data, con) {
     list(people = stats::setNames(

--- a/vignettes/dettl.Rmd
+++ b/vignettes/dettl.Rmd
@@ -14,6 +14,8 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+default_reporter <- testthat::default_reporter()
+options(testthat.default_reporter = "summary")
 ```
 ```{r echo = FALSE, results = "hide"}
 db_name <- "test.sqlite"
@@ -273,8 +275,6 @@ transformed_data <- import$get_transformed_data()
 ```
 
 ```{r echo = FALSE, results = "hide"}
-## Ensure DB removed.
-## We want to keep the DB around until the vignette has completed.
-## TODO: Manage this up using tmp files instead.
-#unlink(db_path2)
+## Reset default reporter.
+options(testthat.default_reporter = default_reporter)
 ```


### PR DESCRIPTION
This PR will
* Print a message when any of the extract, transform or load tests are about to be run
* Print a message when any of them have been successfully run
* Tested that that is the case
* Also take the opportunity to switch to using `summary` reporter in the vignette to avoid escape characters used to control colouring by the default `progress` reporter. 
   * On this point I tried pretty much every reporter and it looks like `summary` is the best option available to me here (no colouring but still printing some useful information but not too verbose). Though it's still not perfect in that it prints a large horizontal line of `=` for formatting which doesn't look great in the vignette. I'm not sure if there is a good way to work around that?