### PR TITLE
Remove checks of single referenced column

### DIFF
--- a/R/foreign_keys.R
+++ b/R/foreign_keys.R
@@ -75,10 +75,6 @@ parse_constraints <- function(constraints_table) {
 
 handle_single_table <- function(table_name, data) {
   referenced_column <- unique(data$referenced_column)
-  if (length(referenced_column) != 1) {
-    stop(sprintf("Primary key for table %s should always be the same. Got primary keys %s.",
-                 table_name, paste(referenced_column, collapse = ", ")))
-  }
   constraints <- list("primary" = referenced_column)
   foreign_keys <- list()
   for (fk_table in data$constraint_table) {

--- a/tests/testthat/test-foreign-keys.R
+++ b/tests/testthat/test-foreign-keys.R
@@ -122,7 +122,7 @@ test_that("table can have more than 1 column constrained on same field", {
   expect_length(constraints$reftable1$foreign$table1, 2)
 })
 
-test_that("only one key can be referenced from each table", {
+test_that("multiple keys can be referenced from each table", {
   data <- data.frame(
     constraint_table = c("table1", "table2"),
     constraint_column = c("col1", "col2"),
@@ -130,8 +130,13 @@ test_that("only one key can be referenced from each table", {
     referenced_column = c("id", "id2"),
     stringsAsFactors = FALSE
   )
-  expect_error(parse_constraints(data),
-    "Primary key for table reftable1 should always be the same. Got primary keys id, id2.")
+  constraints <- parse_constraints(data)
+
+  expect_equal(names(constraints), "reftable1")
+  expect_equal(constraints$reftable1$primary, c("id", "id2"))
+  expect_equal(names(constraints$reftable1$foreign), c("table1", "table2"))
+  expect_equal(constraints$reftable1$foreign$table1, "col1")
+  expect_equal(constraints$reftable1$foreign$table2, "col2")
 })
 
 test_that("unsupported sql dialect returns useful error", {


### PR DESCRIPTION
This PR will:
* Remove check that only one column from each table can ever be referenced in a foreign key (this isn't true as a foreign key constraint could reference a primary key or another column with a unique key constraint)

This is a quick simple fix so not to block development of imports. As part of VIMC-2964 (which I think I should work on next) I expect that we can update the underlying data structure we use to represent the key constraints to make it more flexible and robust. The representation in this PR when we reference more than one column will have some ambiguity. It will look like

```
referenced_table : {
  primary: [id, id2],
  foreign: {
    table1: col1,
    table2: col2
  }
}
```

This should be fine for the time being but in the next PR would should make this less ambiguous. I'm thinking something like

```
referenced_table: {
  foreign : [{
    referenced_column : id1,
    foreign_key : {
      table1: col1
    }
  },
  {
    referenced_column : id2,
    foreign_key : {
      table2 : col2,
      table3 : col3
    }
  }]
}
```

We can then expand that and have a block under the `referenced_table` for the `primary` and `unique` constraints too.