### PR TITLE
Fix bug where code expects all referenced keys to exist within the import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dettl
 Title: Data extract, transform, test and load
-Version: 0.0.5
+Version: 0.0.6
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 0.0.6
+
+VIMC-3022 - Allow upload to not specify serial PKs when they are not referenced
+by any other data within the upload
+
 ## 0.0.5
 
 VIMC-3015 - Expose automatic load function for use in custom load functions

--- a/R/foreign_key_constraints.R
+++ b/R/foreign_key_constraints.R
@@ -43,6 +43,24 @@ ForeignKeyConstraints <- R6::R6Class(
         ))
       }
       foreign_key_constraints
+    },
+
+    is_serial_constraint = function(name, column, data) {
+      ## Is a referenced column in a table actually used as a referenced key
+      ## for this set of data we are uploading? If so then it needs to be
+      ## stripped before upload
+      is_serial <- self$is_serial(name, column)
+      foreign_key_usages <- self$get_foreign_key_usages(name, column)
+      is_used_as_constraint <- FALSE
+      for (usage_name in names(foreign_key_usages)) {
+        if (usage_name %in% names(data)) {
+          table <- data[[usage_name]]
+          if (foreign_key_usages[usage_name] %in% colnames(table)) {
+            is_used_as_constraint <- TRUE
+          }
+        }
+      }
+      is_serial && is_used_as_constraint
     }
   )
 )

--- a/tests/testthat/test-automatic-load.R
+++ b/tests/testthat/test-automatic-load.R
@@ -298,3 +298,67 @@ test_that("map values works as expected", {
   mapped_values <- map_values(data, old, new, "table_name", "col_name")
   expect_equal(mapped_values, c(1, 2, 2, NA, 6, 6, 7))
 })
+
+# test_that("automatic load supports upload without specifying referenced keys", {
+#   path <- prepare_test_import(create_db = FALSE)
+#   con <- prepare_example_postgres_db(add_fk_data = TRUE)
+#   on.exit(DBI::dbDisconnect(con), add = TRUE)
+#
+#   ## When uploading data where serial PK is used as a referenced key in foreign
+#   ## key constraint but table with FK on is NOT being uploaded too
+#   region <- data_frame(name = c("France", "Paris"))
+#
+#   tables <- list(
+#     region = region
+#   )
+#
+#   ## Then data can be uploaded
+#   dettl_auto_load(tables, con)
+#
+#   expected_region <- data_frame(id = c(1, 2, 3, 4),
+#                                name = c("UK", "London", "France", "Paris"),
+#                                parent = c(NA, 1, NA, NA))
+#
+#   region_table <- DBI::dbGetQuery(con, "SELECT * FROM region")
+#   expect_equal(region_table, expected_region)
+# })
+
+test_that("automatic load supports upload without specifying referenced keys", {
+  path <- prepare_test_import(add_fk_data = TRUE)
+  con <- dbi_db_connect(RSQLite::SQLite(), file.path(path, "test.sqlite"))
+
+  ## When uploading data where serial PK is used as a referenced key in foreign
+  ## key constraint but table with FK on is NOT being uploaded too
+  region <- data_frame(name = c("France", "Paris"))
+
+  tables <- list(
+    region = region
+  )
+
+  ## Then data can be uploaded
+  dettl_auto_load(tables, con)
+
+  expected_region <- data_frame(id = c(1, 2, 3, 4),
+                                name = c("UK", "London", "France", "Paris"),
+                                parent = c(NA, 1, NA, NA))
+
+  region_table <- DBI::dbGetQuery(con, "SELECT * FROM region")
+  expect_equal(region_table, expected_region)
+
+  ## When uploading data where serial PK is used as a referenced key in foreign
+  ## key constraints and table with FK on IS being uploaded too
+  region <- data_frame(name = c("Germany"))
+  address <- data_frame(street = "Street", region = 5)
+
+  tables <- list(
+    region = region,
+    address = address
+  )
+
+  ## then PK must be specified
+  expect_error(dettl_auto_load(tables, con),
+               paste0("Can't uploaded data, referenced key 'id' of table ",
+                      "'region' is missing but is referenced by foreign key ",
+                      "constraint used in data."))
+
+})

--- a/tests/testthat/test-foreign-key-constraints.R
+++ b/tests/testthat/test-foreign-key-constraints.R
@@ -48,6 +48,49 @@ test_that("foreign key constraints can be initialised and accessed", {
   expect_true(keys$is_serial("table2", "id"))
   expect_true(keys$is_serial("table2", "nid"))
   expect_equal(keys$is_serial("table2", c("id", "nid")), c(TRUE, TRUE))
+
+  ## We can test if data to be uploaded contains constrained data
+  data <- list(
+    constrained_table3 = data_frame(
+      test = "one",
+      example_field3 = 2
+    ),
+    table_2 = data_frame(
+      test = "two",
+      example_field3 = 3
+    )
+  )
+  expect_false(keys$is_serial_constraint("table", "id", data))
+  expect_true(keys$is_serial_constraint("table2", "id", data))
+
+  data <- list(
+    table_1 = data_frame(
+      test = "one",
+      example_field3 = 2
+    ),
+    table_2 = data_frame(
+      test = "two",
+      example_field3 = 3
+    )
+  )
+  expect_false(keys$is_serial_constraint("table2", "id", data))
+
+  data <- list(
+    constrained_table3 = data_frame(
+      test = "one",
+      field = 2
+    ),
+    table_2 = data_frame(
+      test = "two",
+      example_field3 = 3
+    )
+  )
+  expect_false(keys$is_serial_constraint("table2", "id", data))
+
+  expect_error(keys$is_serial_constraint("missing", "na", data),
+               paste0("Tried to get foreign key usages for referenced table ",
+                      "'missing' and column 'na', table and column are missing",
+                      " from constraints"))
 })
 
 test_that("empty key constraints returns appropriate messages", {


### PR DESCRIPTION
This PR will

* Allow upload of data without specifying autogenerated columns which are referenced by some fk constraint when no other uploaded data references that column
* Throw a useful error should the autogenerated column not be specified when it is referenced by another table within the same upload