### PR TITLE
Running import on prod requires user confirmation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dettl
 Title: Data extract, transform, test and load
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 0.0.7
+
+VIMC-3007 - Users can configure if an import to a particular DB needs to be
+confirmed. If so they are asked a yes/no question when running load step.
+
 ## 0.0.6
 
 VIMC-3022 - Allow upload to not specify serial PKs when they are not referenced

--- a/R/db.R
+++ b/R/db.R
@@ -58,7 +58,7 @@ sqlite_enable_fk <- function(con) {
 dettl_db_args <- function(path, type = NULL) {
   config <- dettl_config(path)
   if (is.null(type)) {
-    type <- names(config$db)[[1]]
+    type <- get_default_type(config)
   }
   x <- config$db[[type]]
   if (is.null(x)) {
@@ -84,6 +84,10 @@ dettl_db_args <- function(path, type = NULL) {
     )
   )
   list(driver = driver, args = resolved_args, log_table = x$log_table)
+}
+
+get_default_type <- function(config) {
+  names(config$db)[[1]]
 }
 
 #' Verify the data adheres to the DB schema.

--- a/R/dettl.R
+++ b/R/dettl.R
@@ -50,7 +50,7 @@ DataImport <- R6::R6Class(
     path = NULL,
     initialize = function(path, extract, extract_test, transform,
                           transform_test, load, load_test, test_queries,
-                          db_name, confirm, rollback = NULL) {
+                          db_name, rollback = NULL) {
       self$path <- path
       ## TODO: Only set up connection when it is actually needed
       private$con <- db_connect(db_name, path)

--- a/R/dettl.R
+++ b/R/dettl.R
@@ -98,7 +98,7 @@ DataImport <- R6::R6Class(
     },
 
     load = function(comment = NULL, dry_run = FALSE, force = FALSE) {
-      if (private$confirm && !dry_run) {
+      if (private$confirm) {
         confirmed <- askYesNo(
           sprintf(
             "About to upload to database %s are you sure you want to proceed?",

--- a/R/dettl.R
+++ b/R/dettl.R
@@ -101,11 +101,12 @@ DataImport <- R6::R6Class(
       if (private$confirm) {
         confirmed <- askYesNo(
           sprintf(
-            "About to upload to database %s are you sure you want to proceed?",
+            "About to upload to database '%s' are you sure you want to proceed?",
             private$db_name),
           default = FALSE)
         if (is.na(confirmed) || !confirmed) {
-          stop("Not uploading to database.")
+          message("Not uploading to database.")
+          return(invisible(FALSE))
         }
       }
       message(sprintf("Running load %s", self$path))

--- a/R/dettl_config.R
+++ b/R/dettl_config.R
@@ -52,7 +52,8 @@ dettl_config_read_yaml <- function(filename, path) {
 
   check_length(info$db, "gt", 0)
   for (db_cfg in names(info$db)) {
-    check_fields(info$db[[db_cfg]], filename, c("driver", "log_table", "args"), NULL)
+    check_fields(info$db[[db_cfg]], filename, c("driver", "log_table", "args"),
+                 "confirm")
     if (is.null(info$db[[db_cfg]]$driver)) {
       stop(sprintf("No driver specified for DB config %s.", db_cfg))
     }
@@ -61,6 +62,9 @@ dettl_config_read_yaml <- function(filename, path) {
     )
     assert_db_name(info$db[[db_cfg]]$log_table,
                    sprintf("%s:%s:log_table", filename, db_cfg))
+    if (is.null(info$db[[db_cfg]]$confirm)) {
+      info$db[[db_cfg]]$confirm <- FALSE
+    }
   }
 
   if (!is.null(info$vault_server)) {

--- a/tests/testthat/helper-dettl-config.R
+++ b/tests/testthat/helper-dettl-config.R
@@ -1,7 +1,8 @@
 setup_config <- function(db_driver = "RSQLite::SQLite",
                          vault_server = "https://example.com",
                          db_pw = "VAULT:/secret/users/readonly:password",
-                         log_table = "data_import_log") {
+                         log_table = "data_import_log",
+                         confirm = FALSE) {
   path <- temp_file()
   dir.create(path)
   filename <- file.path(path, "dettl_config.yml")
@@ -10,6 +11,7 @@ setup_config <- function(db_driver = "RSQLite::SQLite",
   cfg_server <- gsub("<driver>", db_driver, cfg_server, fixed = TRUE)
   cfg_server <- gsub("<db_pw>", db_pw, cfg_server, fixed = TRUE)
   cfg_server <- gsub("<log_table>", log_table, cfg_server, fixed = TRUE)
+  cfg_server <- gsub("<confirm>", confirm, cfg_server, fixed = TRUE)
   writeLines(cfg_server, filename)
   path
 }

--- a/tests/testthat/template_dettl_config/dettl_config.yml
+++ b/tests/testthat/template_dettl_config/dettl_config.yml
@@ -4,6 +4,7 @@ db:
     args:
       dbname: test.sqlite
     log_table: <log_table>
+    confirm: <confirm>
   uat:
     driver: RPostgres::Postgres
     args:

--- a/tests/testthat/test-dettl-config.R
+++ b/tests/testthat/test-dettl-config.R
@@ -16,6 +16,12 @@ test_that("dettl config can be read and database connection info extracted", {
     user = "readonly",
     password = "VAULT:/secret/users/readonly:password")
   )
+  expect_false(cfg$db$example$confirm)
+  expect_false(cfg$db$uat$confirm)
+
+  path <- setup_config(confirm = TRUE)
+  cfg <- dettl_config(path)
+  expect_true(cfg$db$example$confirm)
 })
 
 test_that("reading config throws error if driver is not configured", {

--- a/tests/testthat/test-dettl-runner.R
+++ b/tests/testthat/test-dettl-runner.R
@@ -210,6 +210,74 @@ test_that("run import checks git state before import is run", {
   expect_true(import_load)
 })
 
+test_that("run import asks to confirm run if configured", {
+  path <- prepare_test_import()
+
+  ## Turn off reporting when running import so import tests do not print
+  ## to avoid cluttering up test output.
+  default_reporter <- testthat::default_reporter()
+  options(testthat.default_reporter = "silent")
+  on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
+
+  ## Mock dettl_config return
+  config <- dettl_config(file.path(path, "example/"))
+  config$db[["test"]]$confirm <- TRUE
+  mock_confim_config <- mockery::mock(config, cycle = TRUE)
+  mock_no_answer <- mockery::mock(FALSE, cycle = TRUE)
+  mock_NA_answer <- mockery::mock(NA, cycle = TRUE)
+  mock_yes_answer <- mockery::mock(TRUE, cycle = TRUE)
+
+  with_mock("dettl:::dettl_config" = mock_confim_config,
+            "askYesNo" = mock_no_answer, {
+    import <- dettl(file.path(path, "example/"), db_name = "test")
+    import$extract()
+    import$transform()
+    expect_error(import$load(), "Not uploading to database")
+  })
+
+  with_mock("dettl:::dettl_config" = mock_confim_config,
+            "askYesNo" = mock_NA_answer, {
+    import <- dettl(file.path(path, "example/"), db_name = "test")
+    import$extract()
+    import$transform()
+    expect_error(import$load(), "Not uploading to database")
+  })
+
+  with_mock("dettl:::dettl_config" = mock_confim_config,
+            "askYesNo" = mock_yes_answer, {
+    import <- dettl(file.path(path, "example/"), db_name = "test")
+    import$extract()
+    import$transform()
+    expect_message(import$load(),
+                   sprintf("Running load %s", file.path(path, "example")),
+                   fixed = TRUE)
+  })
+})
+
+test_that("run import doesn't ask to confirm run if not configured", {
+  path <- prepare_test_import()
+
+  ## Turn off reporting when running import so import tests do not print
+  ## to avoid cluttering up test output.
+  default_reporter <- testthat::default_reporter()
+  options(testthat.default_reporter = "silent")
+  on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
+
+  ## Mock dettl_config return
+  config <- dettl_config(file.path(path, "example/"))
+  config$db[["test"]]$confirm <- FALSE
+  mock_no_confirm_config <- mockery::mock(config, cycle = TRUE)
+
+  with_mock("dettl:::dettl_config" = mock_no_confirm_config, {
+    import <- dettl(file.path(path, "example/"), db_name = "test")
+    import$extract()
+    import$transform()
+    expect_message(import$load(),
+                   sprintf("Running load %s", file.path(path, "example")),
+                   fixed = TRUE)
+  })
+})
+
 test_that("extract can be run from path", {
   path <- prepare_test_import()
 


### PR DESCRIPTION
This PR will

* Allow users to configure whether an import needs to be confirmed (via a yes no question) before `load` stage is run