### PR TITLE
Add extracted_data to test environments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dettl
 Title: Data extract, transform, test and load
-Version: 0.0.7
+Version: 0.0.8
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 0.0.8
+
+VIMC-3108 - Allow test_transform to refer to extracted_data
+
 ## 0.0.7
 
 VIMC-3007 - Users can configure if an import to a particular DB needs to be

--- a/R/dettl.R
+++ b/R/dettl.R
@@ -113,7 +113,7 @@ DataImport <- R6::R6Class(
       if (!force && !dry_run && !git_repo_is_clean(self$path)) {
         stop("Can't run load as repository has unstaged changes. Update git or run in dry-run mode.")
       }
-      run_load(private$con, private$load_, private$transformed_data,
+      run_load(private$con, private$load_, private$extracted_data, private$transformed_data,
                private$test_queries, self$path, private$load_test_, dry_run,
                private$log_table, comment)
       invisible(TRUE)

--- a/R/load_runner.R
+++ b/R/load_runner.R
@@ -5,6 +5,7 @@
 #'
 #' @param load The load function for making the DB changes.
 #' @param con Connection to the database.
+#' @param extracted_data Extracted data if needed for testing, otherwise can be NULL.
 #' @param transformed_data List of data frames representing the data to be
 #' loaded to the DB.
 #' @param test_queries Function containing queries for running on the DB before

--- a/R/load_runner.R
+++ b/R/load_runner.R
@@ -20,7 +20,7 @@
 #'
 #' @keywords internal
 #'
-run_load <- function(con, load, transformed_data, test_queries, path,
+run_load <- function(con, load, extracted_data, transformed_data, test_queries, path,
                      test_file, dry_run, log_table, comment) {
   if (is.null(transformed_data)) {
     stop("Cannot run tests as no data has been transformed.")
@@ -30,7 +30,7 @@ run_load <- function(con, load, transformed_data, test_queries, path,
   verify_first_run(con, log_table, log_data)
   DBI::dbBegin(con)
   withCallingHandlers(
-    do_load(con, load, transformed_data, path, test_file, test_queries,
+    do_load(con, load, extracted_data, transformed_data, path, test_file, test_queries,
             log_table, log_data, dry_run),
     error = function(e) {
       DBI::dbRollback(con)
@@ -40,14 +40,14 @@ run_load <- function(con, load, transformed_data, test_queries, path,
   invisible(TRUE)
 }
 
-do_load <- function(con, load, transformed_data, path, test_file, test_queries,
+do_load <- function(con, load, extracted_data, transformed_data, path, test_file, test_queries,
                     log_table, log_data, dry_run) {
   before <- test_queries(con)
   load(transformed_data, con)
   after <- test_queries(con)
   test_path <- file.path(path, test_file)
   message(sprintf("Running load tests %s", test_path))
-  test_results <- run_load_tests(test_path, before, after, con)
+  test_results <- run_load_tests(test_path, before, after, extracted_data, transformed_data, con)
   if (all_passed(test_results)) {
     if (dry_run) {
       DBI::dbRollback(con)

--- a/R/test_runner.R
+++ b/R/test_runner.R
@@ -1,8 +1,10 @@
-run_load_tests <- function(path, before, after, con,
+run_load_tests <- function(path, before, after, extracted_data, transformed_data, con,
                            reporter = testthat::default_reporter()) {
   env <- new.env(parent = .GlobalEnv)
   env$before <- before
   env$after <- after
+  env$extracted_data <- extracted_data
+  env$transformed_data <- transformed_data
   env$con <- con
   test_results <- testthat::test_file(path, env = env, reporter = reporter)
 }

--- a/R/test_runner.R
+++ b/R/test_runner.R
@@ -15,10 +15,11 @@ run_extract_tests <- function(path, extracted_data, con,
   test_results <- testthat::test_file(path, env = env, reporter = reporter)
 }
 
-run_transform_tests <- function(path, transformed_data, con,
+run_transform_tests <- function(path, transformed_data, extracted_data, con,
                                 reporter = testthat::default_reporter()) {
   env <- new.env(parent = .GlobalEnv)
   env$transformed_data <- transformed_data
+  env$extracted_data <- extracted_data
   env$con <- con
   test_results <- testthat::test_file(path, env = env, reporter = reporter)
 }

--- a/R/transform_runner.R
+++ b/R/transform_runner.R
@@ -25,7 +25,7 @@ run_transform <- function(con, transform, path, extracted_data,
       message(sprintf("Running transform tests %s", transform_test))
       test_path <- file.path(path, transform_test)
       test_results <-
-        run_transform_tests(test_path, transformed_data, con)
+        run_transform_tests(test_path, transformed_data, extracted_data, con)
       if (!all_passed(test_results)) {
         stop("Not all transform tests passed. Fix tests before proceeding.")
       } else {

--- a/man/run_load.Rd
+++ b/man/run_load.Rd
@@ -4,13 +4,15 @@
 \alias{run_load}
 \title{Run the load step ensuring tests pass before db changes are committed.}
 \usage{
-run_load(con, load, transformed_data, test_queries, path, test_file,
-  dry_run, log_table, comment)
+run_load(con, load, extracted_data, transformed_data, test_queries, path,
+  test_file, dry_run, log_table, comment)
 }
 \arguments{
 \item{con}{Connection to the database.}
 
 \item{load}{The load function for making the DB changes.}
+
+\item{extracted_data}{Extracted data if needed for testing, otherwise can be NULL.}
 
 \item{transformed_data}{List of data frames representing the data to be
 loaded to the DB.}

--- a/tests/testthat/test-data-import-object.R
+++ b/tests/testthat/test-data-import-object.R
@@ -14,7 +14,7 @@ test_that("format works for functions with many args", {
   ## many arguments
   call <- capture_args(run_load, "run_load", width = 50)
   expect_equal(call,
-"    run_load(con, load, transformed_data,
+"    run_load(con, load, extracted_data = NULL, transformed_data,
         test_queries, path, test_file,
         dry_run, log_table, comment)")
 })

--- a/tests/testthat/test-data-import-object.R
+++ b/tests/testthat/test-data-import-object.R
@@ -16,9 +16,8 @@ test_that("format works for functions with many args", {
   expect_equal(call,
 "    run_load(con, load, extracted_data,
         transformed_data, test_queries,
-        path, test_file,
-        dry_run, log_table,
-	comment)")
+        path, test_file, dry_run, log_table,
+        comment)")
 })
 
 

--- a/tests/testthat/test-data-import-object.R
+++ b/tests/testthat/test-data-import-object.R
@@ -14,7 +14,7 @@ test_that("format works for functions with many args", {
   ## many arguments
   call <- capture_args(run_load, "run_load", width = 50)
   expect_equal(call,
-"    run_load(con, load, extracted_data = NULL, transformed_data,
+"    run_load(con, load, extracted_data, transformed_data,
         test_queries, path, test_file,
         dry_run, log_table, comment)")
 })

--- a/tests/testthat/test-data-import-object.R
+++ b/tests/testthat/test-data-import-object.R
@@ -14,9 +14,11 @@ test_that("format works for functions with many args", {
   ## many arguments
   call <- capture_args(run_load, "run_load", width = 50)
   expect_equal(call,
-"    run_load(con, load, extracted_data, transformed_data,
-        test_queries, path, test_file,
-        dry_run, log_table, comment)")
+"    run_load(con, load, extracted_data,
+        transformed_data, test_queries,
+        path, test_file,
+        dry_run, log_table,
+	comment)")
 })
 
 

--- a/tests/testthat/test-load-runner.R
+++ b/tests/testthat/test-load-runner.R
@@ -18,7 +18,7 @@ testthat::test_that("messages are printed to console when tests are run", {
   ## around this by storing the messages in a variable and checking these
   ## individually.
   run_load_call <- function() {
-    run_load(con, load_func, transformed_data, test_queries,
+    run_load(con, load_func, extracted_data = NULL, transformed_data, test_queries,
              path = test_dir, test_file = test_file, dry_run = FALSE,
              log_table = "dettl_import_log", comment = NULL)
   }
@@ -42,7 +42,7 @@ testthat::test_that("log table is appended to", {
   options(testthat.default_reporter = "Silent")
   on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
 
-  run_load(con, load_func, transformed_data, test_queries, path = test_dir,
+  run_load(con, load_func, extracted_data = NULL, transformed_data, test_queries, path = test_dir,
            test_file = test_file, dry_run = FALSE,
            log_table = "dettl_import_log", comment = "Test comment")
   log_data <- DBI::dbGetQuery(con, "SELECT * FROM dettl_import_log")
@@ -73,7 +73,7 @@ testthat::test_that("postgres log table is appended to", {
   options(testthat.default_reporter = "Silent")
   on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
 
-  run_load(con, load_func, transformed_data, test_queries, path = test_dir,
+  run_load(con, load_func, extracted_data = NULL, transformed_data, test_queries, path = test_dir,
            test_file = test_file, dry_run = FALSE,
            log_table = "dettl_import_log", comment = "Test comment")
   log_data <- DBI::dbGetQuery(con, "SELECT * FROM dettl_import_log")
@@ -103,7 +103,7 @@ testthat::test_that("import fails if log table misconfigured", {
   on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
 
   expect_error(
-    run_load(con, load_func, transformed_data, test_queries, path = test_dir,
+    run_load(con, load_func, extracted_data = NULL, transformed_data, test_queries, path = test_dir,
              test_file = test_file, dry_run = FALSE, log_table = "table log",
              comment = "Test comment"),
     "Cannot import data: Table 'table log' is missing from db schema. Please run dettl::dettl_db_create_log_table first."
@@ -112,7 +112,7 @@ testthat::test_that("import fails if log table misconfigured", {
   mock_build_log_data <- mockery::mock(data_frame(name = "test"))
   with_mock("dettl:::build_log_data" = mock_build_log_data, {
     expect_error(
-      run_load(con, load_func, transformed_data, test_queries, path = test_dir,
+      run_load(con, load_func, extracted_data = NULL, transformed_data, test_queries, path = test_dir,
                test_file = test_file, dry_run = FALSE,
                log_table = "dettl_import_log", comment = "Test comment"),
       "Cannot import data: Column 'date' in table 'dettl_import_log' in DB but is missing from local table."
@@ -132,12 +132,12 @@ test_that("import can only be run once", {
   options(testthat.default_reporter = "Silent")
   on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
 
-  run_load(con, load_func, transformed_data, test_queries,
+  run_load(con, load_func, extracted_data = NULL, transformed_data, test_queries,
            path = test_dir, test_file = test_file,
            dry_run = FALSE, log_table = "dettl_import_log",
            comment = NULL)
 
-  expect_error(run_load(con, load_func, transformed_data, test_queries,
+  expect_error(run_load(con, load_func, extracted_data = NULL, transformed_data, test_queries,
                         path = test_dir, test_file = test_file,
                         dry_run = FALSE, log_table = "dettl_import_log",
                         comment = NULL),
@@ -164,7 +164,7 @@ test_that("transaction is cleaned up if import fails", {
 
   ## Error thrown from bad form of transformed_data
   expect_error(
-    run_load(con, dettl_auto_load, transformed_data, test_queries,
+    run_load(con, dettl_auto_load, extracted_data = NULL, transformed_data, test_queries,
              path = test_dir, test_file = test_file, dry_run = FALSE,
              log_table = "dettl_import_log", comment = "Test comment")
   )
@@ -190,7 +190,7 @@ test_that("postgres transaction is cleaned up if import throws error", {
 
   ## Error thrown from bad form of transformed_data
   expect_error(
-    run_load(con, dettl_auto_load, transformed_data, test_queries,
+    run_load(con, dettl_auto_load, extracted_data = NULL, transformed_data, test_queries,
              path = test_dir, test_file = test_file, dry_run = FALSE,
              log_table = "dettl_import_log", comment = "Test comment")
   )

--- a/tests/testthat/test-test-runner.R
+++ b/tests/testthat/test-test-runner.R
@@ -30,13 +30,13 @@ testthat::test_that("user specified extract tests can be run", {
 testthat::test_that("user specified transform tests can be run", {
   test_path <- "example_tests/failing_transform_test.R"
   transformed_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
-  result <- run_transform_tests(test_path, transformed_data, NULL,
+  result <- run_transform_tests(test_path, extracted_data = NULL, transformed_data, NULL,
                                 SilentReporter)
 
   expect_false(all_passed(result))
 
   test_path <- "example_tests/passing_transform_test.R"
-  result <- run_transform_tests(test_path, transformed_data, NULL,
+  result <- run_transform_tests(test_path, extracted_data = NULL, transformed_data, NULL,
                                 SilentReporter)
 
   expect_true(all_passed(result))
@@ -52,7 +52,7 @@ testthat::test_that("connection is available to tests", {
 
   test_path <- "example_tests/connection_transform_test.R"
   transformed_data <- list("test_data" = data.frame(c(1,2), c(3,4)))
-  result <- run_transform_tests(test_path, transformed_data, con,
+  result <- run_transform_tests(test_path, extracted_data = NULL, transformed_data, con,
                                 SilentReporter)
   expect_true(all_passed(result))
 

--- a/tests/testthat/test-test-runner.R
+++ b/tests/testthat/test-test-runner.R
@@ -4,12 +4,12 @@ testthat::test_that("user specified load tests can be run", {
   test_path <- "example_tests/failing_load_test.R"
   before <- list(count = 0)
   after <- list(count = 2)
-  result <- run_load_tests(test_path, before, after, NULL, SilentReporter)
+  result <- run_load_tests(test_path, before, after, NULL, NULL, NULL, SilentReporter)
 
   expect_false(all_passed(result))
 
   test_path <- "example_tests/passing_load_test.R"
-  result <- run_load_tests(test_path, before, after, NULL, SilentReporter)
+  result <- run_load_tests(test_path, before, after, NULL,NULL, NULL, SilentReporter)
 
   expect_true(all_passed(result))
 })
@@ -59,7 +59,7 @@ testthat::test_that("connection is available to tests", {
   test_path <- "example_tests/connection_load_test.R"
   before <- list(count = 0)
   after <- list(count = 2)
-  result <- run_load_tests(test_path, before, after, con, SilentReporter)
+  result <- run_load_tests(test_path, before, after, NULL, NULL, con, SilentReporter)
   expect_true(all_passed(result))
 
 })


### PR DESCRIPTION
So this PR adds extracted_data into the environment for testing the transform, and adds both the exctracted_data and transformed_data into the environment for testing the load.

For an example that uses this, see https://github.com/vimc/montagu-imports/pull/14 , where the number of rows changed (ie, test_queries and the load tests), and the number of rows in the transformed data depend on the CSV file that I load in at the meta stage. It's intended to be an easily reusable import, should we want to do more adding of burden outcomes to expectations. 

Strictly speaking, I didn't need the transformed_data in my test_load, but it seemed odd to only add the extracted_data and not transformed_data. I suppose one could write more tests that ask, "did all the transformed data *really* end up in this database table, or something...

Anyway, see what you think, and whether there's any better way to fix this in dettl, or in my montagu-import PR...