### PR TITLE
Allow re-running of same import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dettl
 Title: Data extract, transform, test and load
-Version: 0.0.8
+Version: 0.0.9
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 0.0.9
+
+VIMC-3155 - Allow load with force = TRUE to re-run already run imports
+
 ## 0.0.8
 
 VIMC-3108 - Allow test_transform to refer to extracted_data

--- a/R/dettl.R
+++ b/R/dettl.R
@@ -115,7 +115,7 @@ DataImport <- R6::R6Class(
       }
       run_load(private$con, private$load_, private$extracted_data, private$transformed_data,
                private$test_queries, self$path, private$load_test_, dry_run,
-               private$log_table, comment)
+               private$log_table, comment, force)
       invisible(TRUE)
     },
 

--- a/man/run_load.Rd
+++ b/man/run_load.Rd
@@ -5,7 +5,7 @@
 \title{Run the load step ensuring tests pass before db changes are committed.}
 \usage{
 run_load(con, load, extracted_data, transformed_data, test_queries, path,
-  test_file, dry_run, log_table, comment)
+  test_file, dry_run, log_table, comment, force = FALSE)
 }
 \arguments{
 \item{con}{Connection to the database.}
@@ -31,6 +31,9 @@ db will be rolled back.}
 
 \item{comment}{An optional comment to add to the import log table for this
 run.}
+
+\item{force}{If TRUE check that import has previously been run will be
+skipped}
 }
 \description{
 Runs the load function on the DB within a transaction. Then run a set of

--- a/tests/testthat/test-data-import-object.R
+++ b/tests/testthat/test-data-import-object.R
@@ -17,7 +17,7 @@ test_that("format works for functions with many args", {
 "    run_load(con, load, extracted_data,
         transformed_data, test_queries,
         path, test_file, dry_run, log_table,
-        comment)")
+        comment, force = FALSE)")
 })
 
 


### PR DESCRIPTION
This PR will
- Allow users to re-run an import which has already been run using `force = TRUE`
   - This will skip checking that the import has not been run before and will instead append `_n` to the name in the import log where n is the number of times the import has already been run. This is super hacky and should be removed when we properly support re-running imports.

