### PR TITLE
VIMC-3035: reload dettl sources

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
+Depends: R (>= 3.5.0)
 Imports:
     bit64,
     DBI,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dettl
 Title: Data extract, transform, test and load
-Version: 0.0.8
+Version: 0.0.9
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dettl 0.0.9
+
+* The import object's sources can be reloaded with `$reload()`, allowing refreshing of source code and repairing a Postgres connection with a failed transaction (VIMC-3035, partly fixes VIMC-3154)
+
 # dettl 0.0.8
 
 * Allow `test_transform` to refer to `extracted_data` (VIMC-3108)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,25 +1,25 @@
-## 0.0.8
+# dettl 0.0.8
 
-VIMC-3108 - Allow test_transform to refer to extracted_data
+* Allow `test_transform` to refer to `extracted_data` (VIMC-3108)
 
-## 0.0.7
+# dettl 0.0.7
 
-VIMC-3007 - Users can configure if an import to a particular DB needs to be
-confirmed. If so they are asked a yes/no question when running load step.
+* Users can configure if an import to a particular DB needs to be
+confirmed. If so they are asked a yes/no question when running load step (VIMC-3007)
 
-## 0.0.6
+# dettl 0.0.6
 
-VIMC-3022 - Allow upload to not specify serial PKs when they are not referenced
-by any other data within the upload
+* Allow upload to not specify serial PKs when they are not referenced
+by any other data within the upload (VIMC-3022)
 
-## 0.0.5
+# dettl 0.0.5
 
-VIMC-3015 - Expose automatic load function for use in custom load functions
+* Expose automatic load function for use in custom load functions (VIMC-3015)
 
-## 0.0.4
+# dettl 0.0.4
 
-VIMC-3004 - Use gert package instead of system calls to git
+* Use `gert` package instead of system calls to git (VIMC-3004)
 
-## 0.0.3
+# dettl 0.0.3
 
-VIMC-2859 - Read foreign key constraints automatically from the database
+* Read foreign key constraints automatically from the database (VIMC-2859)

--- a/R/dettl.R
+++ b/R/dettl.R
@@ -48,27 +48,30 @@ DataImport <- R6::R6Class(
 
   public = list(
     path = NULL,
-    initialize = function(path, extract, extract_test, transform,
-                          transform_test, load, load_test, test_queries,
-                          db_name, rollback = NULL) {
-      self$path <- path
-      ## TODO: Only set up connection when it is actually needed
-      private$con <- db_connect(db_name, path)
-      private$extract_ <- extract
-      private$extract_test_ <- extract_test
-      private$transform_ <- transform
-      private$transform_test_ <- transform_test
-      private$load_ <- load
-      private$load_test_ <- load_test
-      private$test_queries <- test_queries
-      private$log_table <- db_get_log_table(db_name, path)
-      cfg <- dettl_config(path)
-      if (is.null(db_name)) {
-        db_name <- get_default_type(cfg)
-      }
-      private$confirm <- cfg$db[[db_name]]$confirm
+    initialize = function(path, db_name) {
+      self$path <- normalizePath(path, winslash = "/", mustWork = TRUE)
       private$db_name <- db_name
       lockBinding("path", self)
+      self$reload()
+    },
+
+    reload = function() {
+      dettl_config <- read_config(self$path)
+      if (dettl_config$load$automatic) {
+        load_func <- dettl_auto_load
+      } else {
+        load_func <- dettl_config$load$func
+      }
+      db_name <- private$db_name %||% get_default_type(cfg)
+      private$con <- db_connect(db_name, self$path)
+      private$extract_ <- dettl_config$extract$func
+      private$extract_test_ <- dettl_config$extract$test
+      private$transform_ <- dettl_config$transform$func
+      private$transform_test_ <- dettl_config$transform$test
+      private$load_ <- load_func
+      private$load_test_ <- dettl_config$load$test
+      private$test_queries <- dettl_config$load$verification_queries
+      private$log_table <- db_get_log_table(db_name, self$path)
     },
 
     format = function(brief = FALSE) {

--- a/R/dettl.R
+++ b/R/dettl.R
@@ -62,6 +62,8 @@ DataImport <- R6::R6Class(
       } else {
         load_func <- dettl_config$load$func
       }
+      cfg <- dettl_config(self$path)
+
       db_name <- private$db_name %||% get_default_type(cfg)
       private$con <- db_connect(db_name, self$path)
       private$extract_ <- dettl_config$extract$func
@@ -71,7 +73,9 @@ DataImport <- R6::R6Class(
       private$load_ <- load_func
       private$load_test_ <- dettl_config$load$test
       private$test_queries <- dettl_config$load$verification_queries
+
       private$log_table <- db_get_log_table(db_name, self$path)
+      private$confirm <- cfg$db[[db_name]]$confirm
     },
 
     format = function(brief = FALSE) {

--- a/R/dettl_runner.R
+++ b/R/dettl_runner.R
@@ -9,26 +9,7 @@
 #' @export
 #'
 dettl <- function(path, db_name = NULL) {
-
-  path <- normalizePath(path, winslash = '/', mustWork = TRUE)
-  dettl_config <- read_config(path)
-
-  if (dettl_config$load$automatic) {
-    load_func <- dettl_auto_load
-  } else {
-    load_func <- dettl_config$load$func
-  }
-
-  import <- DataImport$new(path,
-                           extract = dettl_config$extract$func,
-                           extract_test = dettl_config$extract$test,
-                           transform = dettl_config$transform$func,
-                           transform_test = dettl_config$transform$test,
-                           load = load_func,
-                           load_test = dettl_config$load$test,
-                           test_queries = dettl_config$load$verification_queries,
-                           db_name = db_name
-                           )
+  DataImport$new(path, db_name)
 }
 
 #' Run extract stage of an import

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -3,10 +3,10 @@ context("git")
 test_that("git parent directory can be located", {
   path <- build_git_demo()
   root <- git_root_directory(path)
-  expect_equal(root, path)
+  expect_equal(normalizePath(root), normalizePath(path))
 
   root <- git_root_directory(file.path(path, "example", "R"))
-  expect_equal(root, path)
+  expect_equal(normalizePath(root), normalizePath(path))
 
   path <- temp_dir()
   expect_error(git_root_directory(path), sprintf(

--- a/tests/testthat/test-save-data.R
+++ b/tests/testthat/test-save-data.R
@@ -1,6 +1,7 @@
 context("save-data")
 
 test_that("extracted data can be saved", {
+  skip_if_not_installed("readxl")
   path <- prepare_test_import(add_data = TRUE, add_job_table = TRUE)
 
   ## Turn off reporting when running import so import tests do not print
@@ -26,6 +27,7 @@ test_that("extracted data can be saved", {
 })
 
 test_that("transformed data can be saved", {
+  skip_if_not_installed("readxl")
   path <- prepare_test_import(add_data = TRUE, add_job_table = TRUE)
 
   ## Turn off reporting when running import so import tests do not print
@@ -75,6 +77,7 @@ test_that("save data can create new file", {
 })
 
 test_that("saving data with multiple sheets is supported", {
+  skip_if_not_installed("readxl")
   path <- prepare_test_import("example_automatic_load",
                               add_data = TRUE, add_job_table = TRUE)
 
@@ -101,6 +104,7 @@ test_that("saving data with multiple sheets is supported", {
 })
 
 test_that("saving data can save extract and transform at same time", {
+  skip_if_not_installed("readxl")
   path <- prepare_test_import("example_automatic_load",
                               add_data = TRUE, add_job_table = TRUE)
 
@@ -121,7 +125,7 @@ test_that("saving data can save extract and transform at same time", {
                c("extracted_people", "extracted_jobs",
                  "transformed_people", "transformed_jobs"))
 
-   extr_people <- readxl::read_excel(file, sheet = "extracted_people")
+  extr_people <- readxl::read_excel(file, sheet = "extracted_people")
   expect_equal(colnames(extr_people), c("id", "name", "age", "height"))
   expect_equal(nrow(extr_people), 3)
   extr_jobs <- readxl::read_excel(file, sheet = "extracted_jobs")

--- a/tests/testthat/test-test-runner.R
+++ b/tests/testthat/test-test-runner.R
@@ -70,3 +70,23 @@ testthat::test_that("no tests completing counts as passed suite", {
   result <- run_extract_tests(test_path, extracted_data, NULL, SilentReporter)
   expect_true(all_passed(result))
 })
+
+
+test_that("can reload changed sources", {
+  path <- prepare_test_import()
+  default_reporter <- testthat::default_reporter()
+  options(testthat.default_reporter = "silent")
+  on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
+
+  p <- file.path(path, "example", "R", "extract.R")
+  txt <- readLines(p)
+  writeLines(txt[!grepl("raw_data$people", txt, fixed = TRUE)], p)
+
+  import <- dettl(file.path(path, "example/"), db_name = "test")
+  expect_error(import$extract(),
+               "Not all extract tests passed. Fix tests before proceeding")
+
+  writeLines(txt, p)
+  import$reload()
+  expect_error(import$extract(), NA)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -194,7 +194,7 @@ test_that("zip_dir", {
   t <- temp_file()
   dir.create(t, FALSE)
   zip <- zip_dir(t)
-  expect_equal(zip, paste0(t, ".zip"))
+  expect_equal(zip, paste0(normalizePath(t), ".zip"))
 
   mockery::stub(zip_dir, "utils::zip", function(...) -1)
   expect_error(zip_dir(temp_file()), "error running zip")


### PR DESCRIPTION
This PR adds the ability to reload dettl sources without recreating the dettl object. The use case I had for this was debugging a malfunctioning `load` step, while not wanting to rerun a long-running `extract` step.

This partly fixes VIMC-3154 too because the reload will refresh the db connection, which means that a failed transaction is not fatal.

Note that in its current form, the extracted and transformed data remain in the object (probably wanted?).