### PR TITLE
VIMC-3217: option to require a particular branch to run

### DIFF
--- a/R/dettl.R
+++ b/R/dettl.R
@@ -43,6 +43,7 @@ DataImport <- R6::R6Class(
     transformed_data = NULL,
     log_table = NULL,
     confirm = NULL,
+    require_branch = NULL,
     db_name = NULL
   ),
 
@@ -76,6 +77,7 @@ DataImport <- R6::R6Class(
 
       private$log_table <- db_get_log_table(db_name, self$path)
       private$confirm <- cfg$db[[db_name]]$confirm
+      private$require_branch <- cfg$db[[db_name]]$require_branch
     },
 
     format = function(brief = FALSE) {
@@ -105,6 +107,12 @@ DataImport <- R6::R6Class(
     },
 
     load = function(comment = NULL, dry_run = FALSE, force = FALSE) {
+      if (!is.null(private$require_branch)) {
+        if (git_branch(self$path) != private$require_branch) {
+          stop(sprintf("This import can only be run from the '%s' branch",
+                       private$require_branch), call. = FALSE)
+        }
+      }
       if (private$confirm) {
         confirmed <- askYesNo(
           sprintf(

--- a/R/dettl_config.R
+++ b/R/dettl_config.R
@@ -52,8 +52,9 @@ dettl_config_read_yaml <- function(filename, path) {
 
   check_length(info$db, "gt", 0)
   for (db_cfg in names(info$db)) {
-    check_fields(info$db[[db_cfg]], filename, c("driver", "log_table", "args"),
-                 "confirm")
+    check_fields(info$db[[db_cfg]], filename,
+                 c("driver", "log_table", "args"),
+                 c("confirm", "require_branch"))
     if (is.null(info$db[[db_cfg]]$driver)) {
       stop(sprintf("No driver specified for DB config %s.", db_cfg))
     }
@@ -64,6 +65,11 @@ dettl_config_read_yaml <- function(filename, path) {
                    sprintf("%s:%s:log_table", filename, db_cfg))
     if (is.null(info$db[[db_cfg]]$confirm)) {
       info$db[[db_cfg]]$confirm <- FALSE
+    }
+    if (!is.null(info$db[[db_cfg]]$require_branch)) {
+      assert_scalar_character(
+        info$db[[db_cfg]]$require_branch,
+        sprintf("%s:%s:require_branch", filename, db_cfg))
     }
   }
 


### PR DESCRIPTION
This PR will add a new configuration option that specifies a branch required for running a report.  For example, in montagu-imports, we should set this to `master` for the `production` database.

This is only going to stop accidental running of reports on production but would still be useful.