### PR TITLE
vimc-3432: Add basic verbose output to automatic load

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dettl
 Title: Data extract, transform, test and load
-Version: 0.0.10
+Version: 0.0.11
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dettl 0.0.11
+
+* The automatic load functions provide information about their progress while they run (VIMC-3432)
+
 # dettl 0.0.10
 
 * Add "mode" option to dettl config, by default mode is "append". If use "create" then import can only create new tables and not append to existing ones. (VIMC-3426)

--- a/R/automatic_load.R
+++ b/R/automatic_load.R
@@ -34,6 +34,8 @@
 dettl_auto_load <- function(transformed_data, con) {
   rewrite_keys <- ForeignKeyConstraints$new(con)
   for (name in names(transformed_data)) {
+    message(sprintf("Updating %s (adding %d rows)",
+                    name, nrow(transformed_data[[name]])))
     has_serial_foreign_keys <- rewrite_keys$used_as_foreign_key(name) &&
                                rewrite_keys$has_serial(name)
     if (has_serial_foreign_keys) {

--- a/R/dettl_auto_load_create.R
+++ b/R/dettl_auto_load_create.R
@@ -13,10 +13,12 @@
 #'
 #' @keywords internal
 dettl_auto_load_create <- function(transformed_data, con) {
-  create_and_append <- function(table_name) {
-    DBI::dbCreateTable(con, table_name, transformed_data[[table_name]])
-    DBI::dbAppendTable(con, table_name, transformed_data[[table_name]])
+  for (table_name in names(transformed_data)) {
+    d <- transformed_data[[table_name]]
+    message(sprintf("Creating table '%s' (%d rows x %d columns)",
+                    table_name, nrow(d), ncol(d)))
+    DBI::dbCreateTable(con, table_name, d)
+    DBI::dbAppendTable(con, table_name, d)
   }
-  lapply(names(transformed_data), create_and_append)
   invisible(TRUE)
 }

--- a/tests/testthat/test-automatic-load.R
+++ b/tests/testthat/test-automatic-load.R
@@ -89,7 +89,10 @@ test_that("postgres automatic load works as expected", {
   )
 
   ## Do load and check uploaded data
-  dettl_auto_load(tables, con)
+  expect_message(
+    dettl_auto_load(tables, con),
+    "Updating region (adding 2 rows)",
+    fixed = TRUE)
 
   ## Create expected data
   db_region <- data_frame(id = c(1,2,3,4),

--- a/tests/testthat/test-dettl-auto-load-create.R
+++ b/tests/testthat/test-dettl-auto-load-create.R
@@ -10,7 +10,11 @@ test_that("dettl-auto-load-create can create new tables from df", {
 
   con <- get_local_connection()
 
-  expect_true(dettl_auto_load_create(transformed_data, con))
+  expect_message(
+    res <- dettl_auto_load_create(transformed_data, con),
+    "Creating table 'people' (2 rows x 2 columns)",
+    fixed = TRUE)
+  expect_true(res)
 
   expect_equal(DBI::dbGetQuery(con, "SELECT * from people"),
                transformed_data$people)


### PR DESCRIPTION
Small usability tweak as some of the uploads take a while. Could be obviously reformatted a lot more nicely...