### PR TITLE
vimc-3458: Add a script to simplify running things

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     yaml,
     withr,
     writexl
-Suggests: 
+Suggests:
+    docopt,
     knitr,
     mockery,
     readxl,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     DBI,
     gert,
     R6,
+    testthat,
     yaml,
     withr,
     writexl
@@ -28,7 +29,6 @@ Suggests:
     rmarkdown,
     RPostgres,
     RSQLite,
-    testthat,
     vaultr (>= 0.2.2)
 VignetteBuilder: knitr
 Language: en-GB

--- a/R/main.R
+++ b/R/main.R
@@ -1,0 +1,29 @@
+main_parse_args <- function(args = commandArgs(TRUE)) {
+  usage <- "Usage:
+  dettl [options] <path>
+
+Options:
+  --db-name=NAME     Name of the database to use
+  --comment=COMMENT  Comment to add with the import
+  --dry-run          Do the dry run only
+  --force            Allow dirty git
+  --root=PATH        Path to dettl root"
+
+  res <- docopt::docopt(usage, args)
+  list(root = res[["root"]],
+       args = list(path = res[["path"]],
+                   db_name = res[["db-name"]],
+                   comment = res[["comment"]],
+                   dry_run = res[["dry-run"]],
+                   force = res[["force"]]))
+}
+
+
+main <- function(args = commandArgs(TRUE)) {
+  dat <- main_parse_args(args)
+  if (!is.null(dat$root)) {
+    owd <- setwd(dat$root)
+    on.exit(setwd(owd))
+  }
+  do.call(dettl_run_load, dat$args)
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN install_packages \
     RSQLite \
     bit64 \
     gert \
+    testthat \
     vaultr \
     yaml \
     withr \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN install_packages \
     RPostgres \
     RSQLite \
     bit64 \
+    docopt \
     gert \
     testthat \
     vaultr \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,3 +32,5 @@ ENV DETTL_VERSION $DETTL_VERSION
 
 COPY . /src
 RUN R CMD INSTALL /src && rm -rf /src
+
+ENTRYPOINT ["/usr/local/bin/dettl"]

--- a/docker/bin/dettl
+++ b/docker/bin/dettl
@@ -1,0 +1,2 @@
+#!/usr/bin/env Rscript
+dettl:::main()

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -1,0 +1,41 @@
+context("main")
+
+test_that("parse arguments - default", {
+  res <- main_parse_args("path")
+  expect_equal(res,
+               list(root = NULL,
+                    args = list(path = "path", db_name = NULL, comment = NULL,
+                                dry_run = FALSE, force = FALSE)))
+})
+
+
+test_that("parse arguments - set lots", {
+  res <- main_parse_args(c("--root=root", "--db-name=production",
+                           "--comment", "comment", "--dry-run", "--force",
+                           "path"))
+  expect_equal(res,
+               list(root = "root",
+                    args = list(path = "path", db_name = "production",
+                                comment = "comment",
+                                dry_run = TRUE, force = TRUE)))
+})
+
+
+test_that("end to end", {
+  path <- prepare_test_import()
+
+  default_reporter <- testthat::default_reporter()
+  options(testthat.default_reporter = "silent")
+  on.exit(options(testthat.default_reporter = default_reporter), add = TRUE)
+
+  args <- c("--root", path, "--db-name", "test", "example")
+  main(args)
+
+  expected_data <- data_frame(c("Alice", "Bob"),
+                              c(25, 43),
+                              c(175, 187))
+  colnames(expected_data) <- c("name", "age", "height")
+  con <- DBI::dbConnect(RSQLite::SQLite(), file.path(path, "test.sqlite"))
+  expect_equal(DBI::dbGetQuery(con, "SELECT name, age, height from people"),
+               expected_data)
+})


### PR DESCRIPTION
This PR adds a small script to the docker image that we can use to automate running dettl from the command line (as we'll want to do from dettl).  The pattern is the same as used in orderly and other centre work with a small parse function that deals with docopt; this simplifies the testing a bit.