### PR TITLE
Bump version no - forgot to do this in previous PR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dettl
 Title: Data extract, transform, test and load
-Version: 0.0.13
+Version: 0.0.14
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",


### PR DESCRIPTION
Sorry just noticed I forgot to do this in previous PR

Have updated this now to match the version shown in the `NEWS`