### PR TITLE
Enable sql only import to contain multiple statements

### DIFF
--- a/R/sql_load.R
+++ b/R/sql_load.R
@@ -1,11 +1,24 @@
 get_sql_load <- function(path) {
-  statement <- paste(readLines(path), collapse = "\n")
+  ## It is not very nice that we have to read & parse this file to send it to
+  ## DB, ideally we could just execute the file directly on DB but DBI only
+  ## allows sending individual queries atm see
+  ## https://github.com/r-dbi/RPostgres/issues/213
+  sql <- readLines(path)
+  sql <- sql[!is_empty(sql)]
+  statement <- paste(sql, collapse = "\n")
+  statements <- unlist(strsplit(statement, ";", fixed = TRUE))
   function(con) {
     withCallingHandlers(
-      DBI::dbExecute(con, statement),
+      lapply(statements, function(cmd) {
+        DBI::dbExecute(con, cmd)
+      }),
       error = function(e) {
         e$message <- paste0("SQL error:\n", e$message)
         stop(e)
       })
   }
+}
+
+is_empty <- function(x) {
+  is.null(x) | is.na(x) | length(x) == 0 | trimws(x) == ""
 }

--- a/R/sql_load.R
+++ b/R/sql_load.R
@@ -3,15 +3,12 @@ get_sql_load <- function(path) {
   ## DB, ideally we could just execute the file directly on DB but DBI only
   ## allows sending individual queries atm see
   ## https://github.com/r-dbi/RPostgres/issues/213
-  sql <- readLines(path)
-  sql <- sql[!is_empty(sql)]
-  statement <- paste(sql, collapse = "\n")
-  statements <- unlist(strsplit(statement, ";", fixed = TRUE))
+  statements <- parse_sql(path)
   function(con) {
     withCallingHandlers(
-      lapply(statements, function(cmd) {
+      for (cmd in statements) {
         DBI::dbExecute(con, cmd)
-      }),
+      },
       error = function(e) {
         e$message <- paste0("SQL error:\n", e$message)
         stop(e)
@@ -19,6 +16,9 @@ get_sql_load <- function(path) {
   }
 }
 
-is_empty <- function(x) {
-  is.null(x) | is.na(x) | length(x) == 0 | trimws(x) == ""
+parse_sql <- function(path) {
+  sql <- readLines(path)
+  sql <- sql[nzchar(trimws(sql))]
+  statement <- paste(sql, collapse = "\n")
+  unlist(strsplit(statement, ";[\n]*"))
 }

--- a/tests/testthat/test-sql-load.R
+++ b/tests/testthat/test-sql-load.R
@@ -31,3 +31,22 @@ test_that("useful error returned when sql fails to run", {
   expect_error(sql_load(con),
                "SQL error:\nnear \"some\": syntax error")
 })
+
+test_that("sql load can run multiple statements", {
+  t <- tempfile()
+  writeLines(c(
+    "create table test (",
+    "  id INTEGERs",
+    ");",
+    "create table test2 (",
+    "  id INTEGERs",
+    ");",
+    " "
+  ), t)
+
+  sql_load <- get_sql_load(t)
+  expect_type(sql_load, "closure")
+  con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+  expect_warning(sql_load(con), NA)
+  expect_equal(DBI::dbListTables(con), c("test", "test2"))
+})


### PR DESCRIPTION
This does some basic cleaning of sql import statement file and then loops over all statements.

Bit of a pain RPostgres doesn't support this but see notes in code